### PR TITLE
Change Edm resolution behaviour when recursing into types not based on System.Object.

### DIFF
--- a/src/Scrima.Core/EdmTypeProvider.cs
+++ b/src/Scrima.Core/EdmTypeProvider.cs
@@ -90,7 +90,10 @@ namespace Scrima.Core
             }
 
             var baseType = clrType.BaseType != typeof(object)
-                ? ResolveEdmType(clrType.BaseType)
+                ? ResolveEdmType(
+                    clrType: clrType.BaseType,
+                    visitedTypes: visitedTypes
+                  )
                 : null;
 
             var clrTypeProperties = clrType

--- a/src/Scrima.Core/Scrima.Core.csproj
+++ b/src/Scrima.Core/Scrima.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Title>Scrima.NET Core</Title>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Change EdmTypeProvider.cs: Now retains the visitedTypes variable content when recursing into types non base on System.Object.
Change Scrima.Core.csproj: Bump version to 1.2.1 reflecting non-breaking changes.

Addresses stack overflow due to excessive recursion depth when attempting to resolve recursively nested types.