### PR TITLE
Refactoring of functions into classes

### DIFF
--- a/src/Scrima.Core/Scrima.Core.csproj
+++ b/src/Scrima.Core/Scrima.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Title>Scrima.NET Core</Title>
   </PropertyGroup>
 </Project>

--- a/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
+++ b/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.22</Version>
+    <Version>3.1.23</Version>
     <Title>Scrima.NET execution engine for EntityFramework Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
+++ b/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Title>Scrima.NET OData parsing for AspNet.Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
+++ b/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <Title>Scrima.NET OData Swagger schema for Swashbuckle</Title>
   </PropertyGroup>

--- a/src/Scrima.OData/Scrima.OData.csproj
+++ b/src/Scrima.OData/Scrima.OData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Title>Scrima.NET common utilities for OData</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/ExpressionHelper.cs
+++ b/src/Scrima.Queryable/ExpressionHelper.cs
@@ -279,5 +279,15 @@ namespace Scrima.Queryable
 
             throw new QueryOptionsValidationException($"Invalid value '{values}' for enum type {enumType.Name}");
         }
+
+        public static Expression CreateCastExpression(Expression argument, Type targetType)
+        {
+            if (targetType == TypeUtilities.StringType)
+            {
+                return Expression.Call(argument, Methods.ObjectToString);
+            }
+
+            return Expression.Convert(argument, targetType);
+        }
     }
 }

--- a/src/Scrima.Queryable/Functions/CastFunction.cs
+++ b/src/Scrima.Queryable/Functions/CastFunction.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using Scrima.Core.Exceptions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class CastFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "cast";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+
+            var castType = TypeUtilities.ParseTargetType(arguments[1]);
+            if (castType == null)
+            {
+                throw new QueryOptionsValidationException("No proper type for cast specified");
+            }
+
+            return ExpressionHelper.CreateCastExpression(arguments[0], castType);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/CeilingFunction.cs
+++ b/src/Scrima.Queryable/Functions/CeilingFunction.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class CeilingFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "ceiling";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            var ceilArg = arguments[0].Type == TypeUtilities.DoubleType
+                ? arguments[0]
+                : Expression.Convert(arguments[0], TypeUtilities.DoubleType);
+            return Expression.Call(null, Methods.MathCeiling, ceilArg);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/ConcatFunction.cs
+++ b/src/Scrima.Queryable/Functions/ConcatFunction.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Scrima.Core.Exceptions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class ConcatFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "concat";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            if (arguments.Count < 1)
+            {
+                throw new QueryOptionsValidationException($"{FunctionName} needs at least 1 parameter");
+            }
+
+            if (ReflectionHelper.IsEnumerable(arguments[0].Type, out var itemType))
+            {
+                var result = arguments[0];
+                var concatMethod = Methods.EnumerableConcat.MakeGenericMethod(itemType);
+                // ReSharper disable once LoopCanBeConvertedToQuery this one is clearer
+                foreach (var arg in arguments.Skip(1))
+                {
+                    result = Expression.Call(null, concatMethod, result, arg);
+                }
+
+                return result;
+            }
+
+            if (arguments[0].Type == TypeUtilities.StringType)
+            {
+                return Expression.Call(null, Methods.StringConcat,
+                    Expression.NewArrayInit(typeof(object), arguments));
+            }
+
+            return InvalidParameterTypes("strings, enumerables");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/ContainsFunction.cs
+++ b/src/Scrima.Queryable/Functions/ContainsFunction.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class ContainsFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "contains";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+
+            if (arguments[0].Type == TypeUtilities.StringType)
+            {
+                return Expression.Call(arguments[0], Methods.StringContains, arguments[1]);
+            }
+
+            if (!ReflectionHelper.IsEnumerable(arguments[0].Type, out var itemType))
+            {
+                return InvalidParameterTypes("strings, enumerables");
+            }
+
+            var sourceArg = arguments[0];
+            var elementArg = arguments[1];
+
+            var itemIsEnum = TypeUtilities.IsEnumOrNullableEnum(itemType, out var itemEnumType);
+            var argIsEnum = TypeUtilities.IsEnumOrNullableEnum(elementArg.Type, out var argEnumType);
+
+            if (itemType == elementArg.Type || (!itemIsEnum && !argIsEnum))
+            {
+                return Expression.Call(null, Methods.EnumerableContains.MakeGenericMethod(itemType),
+                    sourceArg,
+                    elementArg);
+            }
+
+            // enum case: we need to convert/promote expression to enum types
+
+            var enumType = itemIsEnum ? itemEnumType : argEnumType;
+            var arrayType = itemIsEnum ? itemType : elementArg.Type;
+
+            if (sourceArg is ConstantExpression sourceConstantExpression)
+            {
+                var sourceEnumerable = ((IEnumerable)sourceConstantExpression.Value).Cast<object>()
+                    .ToArray();
+
+                var enumArray = Array.CreateInstance(arrayType, sourceEnumerable.Length);
+
+                for (var index = 0; index < sourceEnumerable.Length; index++)
+                {
+                    var item = sourceEnumerable[index];
+                    enumArray.SetValue(ExpressionHelper.ToEnumValue(enumType, item), index);
+                }
+
+                sourceArg = Expression.Constant(enumArray, enumArray.GetType());
+
+                itemType = arrayType;
+            }
+            else if (elementArg is ConstantExpression elementConstantExpression)
+            {
+                elementArg =
+                    Expression.Constant(ExpressionHelper.ToEnumValue(enumType,
+                        elementConstantExpression.Value));
+            }
+
+            return Expression.Call(null, Methods.EnumerableContains.MakeGenericMethod(itemType),
+                sourceArg,
+                elementArg);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/DateFunction.cs
+++ b/src/Scrima.Queryable/Functions/DateFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class DateFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "date";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeDate);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetDate);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/DayFunction.cs
+++ b/src/Scrima.Queryable/Functions/DayFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class DayFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "day";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeDay);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetDay);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/EndsWithFunction.cs
+++ b/src/Scrima.Queryable/Functions/EndsWithFunction.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class EndsWithFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "endswith";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+            return Expression.Call(arguments[0], Methods.StringEndsWith, arguments[1]);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/FloorFunction.cs
+++ b/src/Scrima.Queryable/Functions/FloorFunction.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class FloorFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "floor";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            var floorArg = arguments[0].Type == TypeUtilities.DoubleType
+                ? arguments[0]
+                : Expression.Convert(arguments[0], TypeUtilities.DoubleType);
+            
+            return Expression.Call(null, Methods.MathFloor, floorArg);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/FractionalSecondFunction.cs
+++ b/src/Scrima.Queryable/Functions/FractionalSecondFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class FractionalSecondFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "fractionalseconds";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMilliseconds);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMilliseconds);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/HourFunction.cs
+++ b/src/Scrima.Queryable/Functions/HourFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class HourFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "hour";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeHour);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetHour);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/IndexOfFunction.cs
+++ b/src/Scrima.Queryable/Functions/IndexOfFunction.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class IndexOfFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "indexof";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+            return Expression.Call(arguments[0], Methods.StringIndexOf, arguments[1]);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/IsOfFunction.cs
+++ b/src/Scrima.Queryable/Functions/IsOfFunction.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using Scrima.Core.Exceptions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class IsOfFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "isof";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+
+            var typeCheckType = TypeUtilities.ParseTargetType(arguments[1]);
+            if (typeCheckType == null)
+            {
+                throw new QueryOptionsValidationException("No proper type for type check specified");
+            }
+
+            return Expression.TypeIs(arguments[0], typeCheckType);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/LengthFunction.cs
+++ b/src/Scrima.Queryable/Functions/LengthFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class LengthFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "length";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.StringType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.StringLength);
+            }
+
+            if (ReflectionHelper.IsEnumerable(arguments[0].Type, out var itemType))
+            {
+                return Expression.Call(null, Methods.EnumerableCount.MakeGenericMethod(itemType), arguments[0]);
+            }
+
+            return InvalidParameterTypes("strings, enumerables");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/MaxDateTimeFunction.cs
+++ b/src/Scrima.Queryable/Functions/MaxDateTimeFunction.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class MaxDateTimeFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "maxdatetime";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 0);
+            return Expression.Constant(DateTimeOffset.MaxValue);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/MinDateTimeFunction.cs
+++ b/src/Scrima.Queryable/Functions/MinDateTimeFunction.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class MinDateTimeFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "mindatetime";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 0);
+            return Expression.Constant(DateTimeOffset.MinValue);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/MinuteFunction.cs
+++ b/src/Scrima.Queryable/Functions/MinuteFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class MinuteFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "minute";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMinute);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMinute);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/MonthFunction.cs
+++ b/src/Scrima.Queryable/Functions/MonthFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class MonthFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "month";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMonth);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMonth);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/NowFunction.cs
+++ b/src/Scrima.Queryable/Functions/NowFunction.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class NowFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "now";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 0);
+            return Expression.Constant(DateTimeOffset.UtcNow);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/RoundFunction.cs
+++ b/src/Scrima.Queryable/Functions/RoundFunction.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class RoundFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "round";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            var roundArg = arguments[0].Type == TypeUtilities.DoubleType
+                ? arguments[0]
+                : Expression.Convert(arguments[0], TypeUtilities.DoubleType);
+            return Expression.Call(null, Methods.MathRound, roundArg);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/ScrimaQueryableFunction.cs
+++ b/src/Scrima.Queryable/Functions/ScrimaQueryableFunction.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Scrima.Core.Exceptions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal abstract class ScrimaQueryableFunction
+    {
+        public abstract string FunctionName { get; }
+
+        protected void ValidateParameterCount(IList<Expression> arguments, params int[] count)
+        {
+            if (count.Length == 1 && arguments.Count != count[0])
+            {
+                throw new QueryOptionsValidationException($"{FunctionName} needs {count[0]} parameters");
+            }
+
+            if (!count.Contains(arguments.Count))
+            {
+                var counts = string.Join(", ", count.Take(count.Length - 1)) + " or " + count.Last();
+                throw new QueryOptionsValidationException($"{FunctionName} needs {counts} parameters");
+            }
+        }
+
+        public abstract Expression CreateExpression(IList<Expression> arguments);
+
+        protected Expression InvalidParameterTypes(string supportedTypes)
+        {
+            throw new QueryOptionsValidationException(
+                $"Unsupported parameters provided to function '{FunctionName}', supported types: {supportedTypes}");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/SecondFunction.cs
+++ b/src/Scrima.Queryable/Functions/SecondFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class SecondFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "second";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeSecond);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetSecond);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/StartsWithFunction.cs
+++ b/src/Scrima.Queryable/Functions/StartsWithFunction.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class StartsWithFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "startswith";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2);
+            return Expression.Call(arguments[0], Methods.StringStartsWith, arguments[1]);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/SubStringFunction.cs
+++ b/src/Scrima.Queryable/Functions/SubStringFunction.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class SubStringFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "substring";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 2, 3);
+
+            if (arguments[0].Type == TypeUtilities.StringType)
+            {
+                if (arguments.Count == 2)
+                {
+                    return Expression.Call(arguments[0], Methods.StringSubstringOneParam,
+                        arguments[1]);
+                }
+
+                return Expression.Call(arguments[0], Methods.StringSubstringTwoParam,
+                    arguments[1],
+                    arguments[2]);
+            }
+
+            if (ReflectionHelper.IsEnumerable(arguments[0].Type, out var itemType))
+            {
+                if (arguments.Count == 2)
+                {
+                    return Expression.Call(null, Methods.EnumerableSkip.MakeGenericMethod(itemType),
+                        arguments[0],
+                        arguments[1]);
+                }
+
+                var skip = Expression.Call(null, Methods.EnumerableSkip.MakeGenericMethod(itemType),
+                    arguments[0],
+                    arguments[1]);
+
+                return Expression.Call(null, Methods.EnumerableTake.MakeGenericMethod(itemType),
+                    skip,
+                    arguments[2]);
+            }
+
+            return InvalidParameterTypes("strings, enumerables");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/TimeFunction.cs
+++ b/src/Scrima.Queryable/Functions/TimeFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class TimeFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "time";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeTime);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetTime);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/ToLowerFunction.cs
+++ b/src/Scrima.Queryable/Functions/ToLowerFunction.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class ToLowerFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "tolower";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type != TypeUtilities.StringType)
+            {
+                return InvalidParameterTypes("strings");
+            }
+
+            return Expression.Call(arguments[0], Methods.StringToLowerInvariant);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/ToUpperFunction.cs
+++ b/src/Scrima.Queryable/Functions/ToUpperFunction.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class ToUpperFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "toupper";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type != TypeUtilities.StringType)
+            {
+                return InvalidParameterTypes("strings");
+            }
+
+            return Expression.Call(arguments[0], Methods.StringToUpperInvariant);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/TotalOffsetMinutesFunction.cs
+++ b/src/Scrima.Queryable/Functions/TotalOffsetMinutesFunction.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class TotalOffsetMinutesFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "totaloffsetminutes";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type != TypeUtilities.DateTimeOffsetType)
+            {
+                return InvalidParameterTypes("DateTimeOffset");
+            }
+            
+            return Expression.MakeMemberAccess(
+                Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetOffset),
+                Methods.TimeSpanTotalMinutes);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/TrimFunction.cs
+++ b/src/Scrima.Queryable/Functions/TrimFunction.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class TrimFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "trim";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type != TypeUtilities.StringType)
+            {
+                return InvalidParameterTypes("strings");
+            }
+
+            return Expression.Call(arguments[0], Methods.StringTrim);
+        }
+    }
+}

--- a/src/Scrima.Queryable/Functions/YearFunction.cs
+++ b/src/Scrima.Queryable/Functions/YearFunction.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable.Functions
+{
+    internal class YearFunction : ScrimaQueryableFunction
+    {
+        public override string FunctionName => "year";
+
+        public override Expression CreateExpression(IList<Expression> arguments)
+        {
+            ValidateParameterCount(arguments, 1);
+
+            if (arguments[0].Type == TypeUtilities.DateTimeType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeYear);
+            }
+
+            if (arguments[0].Type == TypeUtilities.DateTimeOffsetType)
+            {
+                return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetYear);
+            }
+
+            return InvalidParameterTypes("DateTime, DateTimeOffset");
+        }
+    }
+}

--- a/src/Scrima.Queryable/Scrima.Queryable.csproj
+++ b/src/Scrima.Queryable/Scrima.Queryable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Title>Scrima.NET execution engine for IQueryable sources</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/ScrimaExtensions.Where.cs
+++ b/src/Scrima.Queryable/ScrimaExtensions.Where.cs
@@ -1,16 +1,24 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Scrima.Core.Exceptions;
 using Scrima.Core.Query;
 using Scrima.Core.Query.Expressions;
+using Scrima.Queryable.Functions;
 
 namespace Scrima.Queryable
 {
     public static partial class ScrimaExtensions
     {
+        private static readonly IDictionary<string, ScrimaQueryableFunction> AvailableFunctions = typeof(ScrimaQueryableFunction)
+            .Assembly
+            .GetTypes()
+            .Where(t => typeof(ScrimaQueryableFunction).IsAssignableFrom(t) && !t.IsAbstract)
+            .Select(Activator.CreateInstance)
+            .Cast<ScrimaQueryableFunction>()
+            .ToDictionary(s => s.FunctionName, s => s, StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Filters a sequence of values based on the provided <see cref="FilterQueryOption"/>
         /// </summary>
@@ -46,7 +54,7 @@ namespace Scrima.Queryable
                     CreateFunctionCallExpression(functionCall.Name,
                         functionCall.Parameters.CreateExpressions(baseExpression)),
 
-                UnaryOperatorNode {OperatorKind: UnaryOperatorKind.Not} unaryOperator =>
+                UnaryOperatorNode { OperatorKind: UnaryOperatorKind.Not } unaryOperator =>
                     Expression.Not(CreateExpression(unaryOperator.Operand, baseExpression)),
 
                 BinaryOperatorNode binaryOperator =>
@@ -57,7 +65,7 @@ namespace Scrima.Queryable
         }
 
         private static IList<Expression> CreateExpressions(this IEnumerable<QueryNode> nodes, Expression baseExpression)
-            => nodes.Select(n => CreateExpression(n, baseExpression)).ToList();
+            => nodes.Select(n => CreateExpression(n, baseExpression)).ToArray();
 
         /// <summary>
         /// Creates an expression from a binary operation like: left OPERATOR right
@@ -85,7 +93,7 @@ namespace Scrima.Queryable
 
             // collection contains
             if (kind == BinaryOperatorKind.In)
-                return CreateFunctionCallExpression("contains", new List<Expression> {right, left});
+                return CreateFunctionCallExpression("contains", new []{ right, left });
 
             var expressionType = kind switch
             {
@@ -124,13 +132,13 @@ namespace Scrima.Queryable
         {
             switch (valueNode)
             {
-                case ConstantNode {Value: null}:
+                case ConstantNode { Value: null }:
                     return Expression.Constant(null);
 
-                case ConstantNode {Value: { }} constant:
+                case ConstantNode { Value: { } } constant:
                     return Expression.Constant(constant.Value, constant.EdmType.ClrType);
 
-                case ArrayNode {Value: { }} array:
+                case ArrayNode { Value: { } } array:
                     return Expression.Constant(array.Value, array.ArrayClrType);
 
                 case PropertyAccessNode propertyAccess:
@@ -156,519 +164,12 @@ namespace Scrima.Queryable
 
         private static Expression CreateFunctionCallExpression(string functionName, IList<Expression> arguments)
         {
-            void ValidateParameterCount(params int[] count)
+            if (!AvailableFunctions.TryGetValue(functionName, out var function))
             {
-                if (count.Length == 1 && arguments.Count != count[0])
-                {
-                    throw new QueryOptionsValidationException($"{functionName} needs {count[0]} parameters");
-                }
-
-                if (!count.Contains(arguments.Count))
-                {
-                    var counts = string.Join(", ", count.Take(count.Length - 1)) + " or " + count.Last();
-                    throw new QueryOptionsValidationException($"{functionName} needs {counts} parameters");
-                }
+                throw new QueryOptionsValidationException($"Could not find any function '{functionName}'");
             }
 
-            Expression InvalidParameterTypes(string supportedTypes)
-            {
-                throw new QueryOptionsValidationException(
-                    $"Unsupported parameters provided to function '{functionName}', supported types: {supportedTypes}");
-            }
-
-            Type itemType;
-
-            switch (functionName)
-            {
-                // string functions
-                case "concat":
-                    if (arguments.Count < 1)
-                    {
-                        throw new QueryOptionsValidationException($"{functionName} needs at least 1 parameter");
-                    }
-
-                    if (ReflectionHelper.IsEnumerable(arguments[0].Type, out itemType))
-                    {
-                        var result = arguments[0];
-                        var concatMethod = Methods.EnumerableConcat.MakeGenericMethod(itemType);
-                        // ReSharper disable once LoopCanBeConvertedToQuery this one is clearer
-                        foreach (var arg in arguments.Skip(1))
-                        {
-                            result = Expression.Call(null, concatMethod, result, arg);
-                        }
-
-                        return result;
-                    }
-                    else if (arguments[0].Type == StringType)
-                    {
-                        return Expression.Call(null, Methods.StringConcat,
-                            Expression.NewArrayInit(typeof(object), arguments));
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings, enumerables");
-                    }
-
-                case "contains":
-                    ValidateParameterCount(2);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        return Expression.Call(arguments[0], Methods.StringContains, arguments[1]);
-                    }
-                    else if (ReflectionHelper.IsEnumerable(arguments[0].Type, out itemType))
-                    {
-                        var sourceArg = arguments[0];
-                        var elementArg = arguments[1];
-
-                        var itemIsEnum = IsEnumOrNullableEnum(itemType, out var itemEnumType);
-                        var argIsEnum = IsEnumOrNullableEnum(elementArg.Type, out var argEnumType);
-
-                        if (itemType != elementArg.Type && (itemIsEnum || argIsEnum))
-                        {
-                            // enum: we need to convert/promote expression to enum types
-
-                            var enumType = itemIsEnum ? itemEnumType : argEnumType;
-                            var arrayType = itemIsEnum ? itemType : elementArg.Type;
-
-                            if (sourceArg is ConstantExpression sourceConstantExpression)
-                            {
-                                var sourceEnumerable = ((IEnumerable)sourceConstantExpression.Value).Cast<object>()
-                                    .ToArray();
-
-                                var enumArray = Array.CreateInstance(arrayType, sourceEnumerable.Length);
-
-                                for (var index = 0; index < sourceEnumerable.Length; index++)
-                                {
-                                    var item = sourceEnumerable[index];
-                                    enumArray.SetValue(ExpressionHelper.ToEnumValue(enumType, item), index);
-                                }
-
-                                sourceArg = Expression.Constant(enumArray, enumArray.GetType());
-
-                                itemType = arrayType;
-                            }
-                            else if (elementArg is ConstantExpression elementConstantExpression)
-                            {
-                                elementArg =
-                                    Expression.Constant(ExpressionHelper.ToEnumValue(enumType,
-                                        elementConstantExpression.Value));
-                            }
-                        }
-
-                        return Expression.Call(null, Methods.EnumerableContains.MakeGenericMethod(itemType),
-                            sourceArg,
-                            elementArg);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings, enumerables");
-                    }
-
-                case "endswith":
-                    ValidateParameterCount(2);
-                    return Expression.Call(arguments[0], Methods.StringEndsWith, arguments[1]);
-
-                case "indexof":
-                    ValidateParameterCount(2);
-                    return Expression.Call(arguments[0], Methods.StringIndexOf, arguments[1]);
-
-                case "length":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.StringLength);
-                    }
-                    else if (ReflectionHelper.IsEnumerable(arguments[0].Type, out itemType))
-                    {
-                        return Expression.Call(null, Methods.EnumerableCount.MakeGenericMethod(itemType), arguments[0]);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings, enumerables");
-                    }
-
-                case "startswith":
-                    ValidateParameterCount(2);
-                    return Expression.Call(arguments[0], Methods.StringStartsWith, arguments[1]);
-
-                case "substring":
-                    ValidateParameterCount(2, 3);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        if (arguments.Count == 2)
-                        {
-                            return Expression.Call(arguments[0], Methods.StringSubstringOneParam,
-                                arguments[1]);
-                        }
-
-                        return Expression.Call(arguments[0], Methods.StringSubstringTwoParam,
-                            arguments[1],
-                            arguments[2]);
-                    }
-                    else if (ReflectionHelper.IsEnumerable(arguments[0].Type, out itemType))
-                    {
-                        if (arguments.Count == 2)
-                        {
-                            return Expression.Call(null, Methods.EnumerableSkip.MakeGenericMethod(itemType),
-                                arguments[0],
-                                arguments[1]);
-                        }
-
-                        var skip = Expression.Call(null, Methods.EnumerableSkip.MakeGenericMethod(itemType),
-                            arguments[0],
-                            arguments[1]);
-
-                        return Expression.Call(null, Methods.EnumerableTake.MakeGenericMethod(itemType),
-                            skip,
-                            arguments[2]);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings, enumerables");
-                    }
-
-                case "tolower":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        return Expression.Call(arguments[0], Methods.StringToLowerInvariant);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings");
-                    }
-                case "toupper":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        return Expression.Call(arguments[0], Methods.StringToUpperInvariant);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings");
-                    }
-                case "trim":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == StringType)
-                    {
-                        return Expression.Call(arguments[0], Methods.StringTrim);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("strings");
-                    }
-
-                // date and time functions
-                case "date":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeDate);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetDate);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "time":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeTime);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetTime);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "totaloffsetminutes":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(
-                            Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetOffset),
-                            Methods.TimeSpanTotalMinutes);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTimeOffset");
-                    }
-
-                case "day":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeDay);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetDay);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "month":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMonth);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMonth);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "year":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeYear);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetYear);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "hour":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeHour);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetHour);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "minute":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMinute);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMinute);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "second":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeSecond);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetSecond);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "fractionalseconds":
-                    ValidateParameterCount(1);
-
-                    if (arguments[0].Type == DateTimeType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeMilliseconds);
-                    }
-                    else if (arguments[0].Type == DateTimeOffsetType)
-                    {
-                        return Expression.MakeMemberAccess(arguments[0], Methods.DateTimeOffsetMilliseconds);
-                    }
-                    else
-                    {
-                        return InvalidParameterTypes("DateTime, DateTimeOffset");
-                    }
-
-                case "maxdatetime":
-                    ValidateParameterCount(0);
-                    return Expression.Constant(DateTimeOffset.MaxValue);
-
-                case "mindatetime":
-                    ValidateParameterCount(0);
-                    return Expression.Constant(DateTimeOffset.MinValue);
-
-                case "now":
-                    ValidateParameterCount(0);
-                    return Expression.Constant(DateTimeOffset.UtcNow);
-
-                // arithmetic functions
-                case "ceiling":
-                    ValidateParameterCount(1);
-
-                    var ceilArg = arguments[0].Type == DoubleType
-                        ? arguments[0]
-                        : Expression.Convert(arguments[0], DoubleType);
-                    return Expression.Call(null, Methods.MathCeiling, ceilArg);
-
-                case "floor":
-                    ValidateParameterCount(1);
-
-                    var floorArg = arguments[0].Type == DoubleType
-                        ? arguments[0]
-                        : Expression.Convert(arguments[0], DoubleType);
-                    return Expression.Call(null, Methods.MathFloor, floorArg);
-
-                case "round":
-                    ValidateParameterCount(1);
-
-                    var roundArg = arguments[0].Type == DoubleType
-                        ? arguments[0]
-                        : Expression.Convert(arguments[0], DoubleType);
-                    return Expression.Call(null, Methods.MathRound, roundArg);
-
-                // type functions
-                case "cast":
-                    ValidateParameterCount(2);
-
-                    var castType = ParseTargetType(arguments[1]);
-                    if (castType == null)
-                    {
-                        throw new QueryOptionsValidationException("No proper type for cast specified");
-                    }
-
-                    return CreateCastExpression(arguments[0], castType);
-
-                case "isof":
-                    ValidateParameterCount(2);
-
-                    var typeCheckType = ParseTargetType(arguments[1]);
-                    if (typeCheckType == null)
-                    {
-                        throw new QueryOptionsValidationException("No proper type for type check specified");
-                    }
-
-                    return Expression.TypeIs(arguments[0], typeCheckType);
-
-                default:
-                    throw new QueryOptionsValidationException($"Could not find any function '{functionName}'");
-            }
+            return function.CreateExpression(arguments);
         }
-
-        private static bool IsEnumOrNullableEnum(Type itemType, out Type enumType)
-        {
-            enumType = null;
-
-            if (itemType.IsEnum)
-            {
-                enumType = itemType;
-                return true;
-            }
-
-            var underlyingType = Nullable.GetUnderlyingType(itemType);
-
-            if (underlyingType?.IsEnum == true)
-            {
-                enumType = underlyingType;
-                return true;
-            }
-
-            return false;
-        }
-
-        private static Type ParseTargetType(Expression argument)
-        {
-            var targetType = (argument as ConstantExpression)?.Value as Type;
-            if (targetType != null)
-            {
-                return targetType;
-            }
-
-            var typeName = (argument as ConstantExpression)?.Value?.ToString();
-            targetType = GetBuiltInTypeByName(typeName);
-            if (targetType != null)
-            {
-                return targetType;
-            }
-
-            return null;
-        }
-
-        private static Expression CreateCastExpression(Expression argument, Type targetType)
-        {
-            if (targetType == StringType)
-            {
-                return Expression.Call(argument, Methods.ObjectToString);
-            }
-
-            return Expression.Convert(argument, targetType);
-        }
-
-        private static Type GetBuiltInTypeByName(string typeName)
-        {
-            // primitiveTypeName
-            if (typeName.StartsWith("Edm."))
-            {
-                typeName = typeName.Substring(4);
-            }
-
-            return typeName switch
-            {
-                "Boolean" => typeof(bool),
-                "Byte" => typeof(byte),
-                "Date" => DateTimeType,
-                "DateTimeOffset" => DateTimeOffsetType,
-                "Decimal" => typeof(decimal),
-                "Double" => DoubleType,
-                "Duration" => typeof(TimeSpan),
-                "Guid" => typeof(Guid),
-                "Int16" => typeof(short),
-                "Int32" => typeof(int),
-                "Int64" => typeof(long),
-                "SByte" => typeof(sbyte),
-                "Single" => typeof(float),
-                "String" => StringType,
-                "TimeOfDay" => typeof(TimeSpan),
-                _ => null
-            };
-        }
-
-        private static readonly Type StringType = typeof(string);
-        private static readonly Type DoubleType = typeof(double);
-        private static readonly Type DateTimeOffsetType = typeof(DateTimeOffset);
-        private static readonly Type DateTimeType = typeof(DateTime);
     }
 }

--- a/src/Scrima.Queryable/TypeUtilities.cs
+++ b/src/Scrima.Queryable/TypeUtilities.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Scrima.Queryable
+{
+    public static class TypeUtilities
+    {
+        public static readonly Type StringType = typeof(string);
+        public static readonly Type DoubleType = typeof(double);
+        public static readonly Type DateTimeOffsetType = typeof(DateTimeOffset);
+        public static readonly Type DateTimeType = typeof(DateTime);
+
+        public static bool IsEnumOrNullableEnum(Type itemType, out Type enumType)
+        {
+            enumType = null;
+
+            if (itemType.IsEnum)
+            {
+                enumType = itemType;
+                return true;
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(itemType);
+
+            if (underlyingType?.IsEnum == true)
+            {
+                enumType = underlyingType;
+                return true;
+            }
+
+            return false;
+        }
+
+        public static Type ParseTargetType(Expression argument)
+        {
+            if (argument is not ConstantExpression constantExpression)
+                return null;
+            
+            if (constantExpression.Value is Type targetType)
+            {
+                return targetType;
+            }
+
+            var typeName = constantExpression.Value?.ToString();
+            
+            return GetBuiltInTypeByName(typeName);
+        }
+
+        private static Type GetBuiltInTypeByName(string typeName)
+        {
+            // primitiveTypeName
+            if (typeName.StartsWith("Edm."))
+            {
+                typeName = typeName.Substring(4);
+            }
+
+            return typeName switch
+            {
+                "Boolean" => typeof(bool),
+                "Byte" => typeof(byte),
+                "Date" => DateTimeType,
+                "DateTimeOffset" => DateTimeOffsetType,
+                "Decimal" => typeof(decimal),
+                "Double" => DoubleType,
+                "Duration" => typeof(TimeSpan),
+                "Guid" => typeof(Guid),
+                "Int16" => typeof(short),
+                "Int32" => typeof(int),
+                "Int64" => typeof(long),
+                "SByte" => typeof(sbyte),
+                "Single" => typeof(float),
+                "String" => StringType,
+                "TimeOfDay" => typeof(TimeSpan),
+                _ => null
+            };
+        }
+    }
+}


### PR DESCRIPTION
First refactoring of function calls for Scrima IQueryable helpers into separate classes:
- Removed big switch for matching function name
- Moved functions call validation and behavior inside respective classes
- Created base class for all kind of callable functions
- Initialized all available functions into a static dictionary
