### PR TITLE
Fix encoded illegal characters in filter string

### DIFF
--- a/src/Scrima.Core/Scrima.Core.csproj
+++ b/src/Scrima.Core/Scrima.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Title>Scrima.NET Core</Title>
   </PropertyGroup>
 </Project>

--- a/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
+++ b/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.23</Version>
+    <Version>3.1.24</Version>
     <Title>Scrima.NET execution engine for EntityFramework Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
+++ b/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Title>Scrima.NET OData parsing for AspNet.Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
+++ b/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <Title>Scrima.NET OData Swagger schema for Swashbuckle</Title>
   </PropertyGroup>

--- a/src/Scrima.OData/Parsers/ConstantNodeParser.cs
+++ b/src/Scrima.OData/Parsers/ConstantNodeParser.cs
@@ -92,7 +92,7 @@ namespace Scrima.OData.Parsers
                     return ConstantNode.Single(token.Value, singleValue);
 
                 case TokenType.String:
-                    var stringText = token.Value.Trim('\'').Replace("''", "'");
+                    var stringText = UnescapeStringText(token.Value);
                     return ConstantNode.String(token.Value, stringText);
 
                 case TokenType.TimeOfDay:
@@ -105,6 +105,19 @@ namespace Scrima.OData.Parsers
                 default:
                     throw new NotSupportedException(token.TokenType.ToString());
             }
+        }
+
+        private static string UnescapeStringText(string tokenValue)
+        {
+            return tokenValue
+                    .Trim('\'')
+                    .Replace("''", "'")
+                    .Replace("%2B", "+")
+                    .Replace("%2F", "/")
+                    .Replace("%3F", "?")
+                    .Replace("%25", "%")
+                    .Replace("%23", "#")
+                    .Replace("%26", "&");
         }
     }
 }

--- a/src/Scrima.OData/Parsers/FilterExpressionLexer.cs
+++ b/src/Scrima.OData/Parsers/FilterExpressionLexer.cs
@@ -31,7 +31,7 @@ namespace Scrima.OData.Parsers
             new TokenDefinition(TokenType.Duration,             @"duration'(-)?P\d+DT\d{2}H\d{2}M\d{2}\.\d+S'"),
             new TokenDefinition(TokenType.Enum,                 @"\w+(\.\w+)+'\w+(\,\w+)*'"),
             new TokenDefinition(TokenType.PropertyName,         @"[\w\/]+"),
-            new TokenDefinition(TokenType.String,               @"'(?:''|[\w\s-.~!$&()*+,;=@\\\/]*)*'"),
+            new TokenDefinition(TokenType.String,               @"'(?:''|[\w\s-.~!$&()*+,;=@%\\\/]*)*'"),
             new TokenDefinition(TokenType.Whitespace,           @"\s", ignore: true),
         };
 

--- a/src/Scrima.OData/Scrima.OData.csproj
+++ b/src/Scrima.OData/Scrima.OData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Title>Scrima.NET common utilities for OData</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/Scrima.Queryable.csproj
+++ b/src/Scrima.Queryable/Scrima.Queryable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Title>Scrima.NET execution engine for IQueryable sources</Title>
   </PropertyGroup>
 

--- a/test/Scrima.Integration.Tests/FilterTests.cs
+++ b/test/Scrima.Integration.Tests/FilterTests.cs
@@ -113,6 +113,19 @@ namespace Scrima.Integration.Tests
         }
 
         [Fact]
+        public async Task Should_ReturnFiltered_When_FilteringOnStringContainsWithSlash()
+        {
+            const int testUserCount = 10;
+            using var server = SetupSample(CreateUsers(testUserCount));
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<User>("/users?%24filter=contains(domainid%2C%27%252F4%27)");
+
+            response.Results.Should().ContainSingle();
+            response.Results[0].Username.Should().Be("user4");
+        }
+
+        [Fact]
         public async Task Should_ReturnFiltered_When_FilteringOnArrayContains()
         {
             const int testUserCount = 10;
@@ -299,6 +312,7 @@ namespace Scrima.Integration.Tests
                 EMail = $"user{i}@email.com",
                 FirstName = $"Jon{i}",
                 LastName = $"Smith{i}",
+                DomainId = $"Smith/{i}",
                 CreatedAt = new DateTimeOffset(2021, 1, i, 10, 0, 0, TimeSpan.Zero),
                 Engagement = 0.2 + i,
                 PayedAmout = (i % 2) * 25.30m,

--- a/test/Scrima.Integration.Tests/Models/User.cs
+++ b/test/Scrima.Integration.Tests/Models/User.cs
@@ -26,5 +26,6 @@ namespace Scrima.Integration.Tests.Models
 
         public double Engagement { get; set; }
         public decimal PayedAmout { get; set; }
+        public string DomainId { get; set; } = string.Empty;
     }
 }

--- a/test/Scrima.OData.Tests/RawParserTests.cs
+++ b/test/Scrima.OData.Tests/RawParserTests.cs
@@ -38,5 +38,24 @@ namespace Scrima.OData.Tests
             rawQueryParsed.Skip.Should().BeNull();
             rawQueryParsed.SkipToken.Should().BeNull();
         }
+        
+        [Theory]
+        [InlineData("?$filter=name eq '/Jon'")]
+        [InlineData("$filter=name eq '/Jon'")]
+        [InlineData("$filter=name eq '%2FJon'")]
+        [InlineData("%24filter=name+eq+%27%2FJon%27")]
+        public void Should_ParseRawString_When_ContainsSlash(string rawQueryString)
+        {
+            var rawQueryParsed = ODataRawQueryOptions.ParseRawQuery(rawQueryString);
+
+            rawQueryParsed.Should().NotBeNull();
+            rawQueryParsed.Filter.Should().Be("name eq '/Jon'");
+            rawQueryParsed.Count.Should().BeNull();
+            rawQueryParsed.Search.Should().BeNull();
+            rawQueryParsed.OrderBy.Should().BeNull();
+            rawQueryParsed.Top.Should().BeNull();
+            rawQueryParsed.Skip.Should().BeNull();
+            rawQueryParsed.SkipToken.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
Fixed issue that disallowed double-encoded characters inside `$filter` param, for:

| Special character | Hexadecimal value |
|-------------------|-------------------|
| +                 | %2B               |
| /                 | %2F               |
| ?                 | %3F               |
| %                 | %25               |
| #                 | %23               |
| &                 | %26               |