### PR TITLE
fix(OrderBy): allow nullable properties

### DIFF
--- a/src/Scrima.Core/Scrima.Core.csproj
+++ b/src/Scrima.Core/Scrima.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Scrima.NET Core</Title>
   </PropertyGroup>
 </Project>

--- a/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
+++ b/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <Title>Scrima.NET execution engine for EntityFramework Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
+++ b/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Scrima.NET OData parsing for AspNet.Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
+++ b/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <Title>Scrima.NET OData Swagger schema for Swashbuckle</Title>
   </PropertyGroup>

--- a/src/Scrima.OData/Scrima.OData.csproj
+++ b/src/Scrima.OData/Scrima.OData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Scrima.NET common utilities for OData</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/Scrima.Queryable.csproj
+++ b/src/Scrima.Queryable/Scrima.Queryable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Scrima.NET execution engine for IQueryable sources</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/ScrimaExtensions.OrderBy.cs
+++ b/src/Scrima.Queryable/ScrimaExtensions.OrderBy.cs
@@ -41,7 +41,7 @@ namespace Scrima.Queryable
                 var sortMethodInfo = GetQueryableSortMethodInfo(clause.Direction, isFirstClause);
 
                 var sortMethod =
-                    sortMethodInfo.MakeGenericMethod(source.ElementType, clause.Property.PropertyType.ClrType);
+                    sortMethodInfo.MakeGenericMethod(source.ElementType, propertyExpression.Type);
 
                 // create a new query expression which includes the sort call
                 var queryExpression = Expression.Call(null, sortMethod, source.Expression, selectorExpression);

--- a/test/Scrima.Queryable.Tests/QueryableTests.cs
+++ b/test/Scrima.Queryable.Tests/QueryableTests.cs
@@ -614,6 +614,37 @@ namespace Scrima.Queryable.Tests
             var value = results.Results.First();
             value.Id.Should().Be(3);
         }
+        
+        [Theory]
+        [InlineData(OrderByDirection.Ascending, null)]
+        [InlineData(OrderByDirection.Descending, "2/1/2021 12:00:00 AM")]
+        public void Should_orderby_on_datetimenullable_property(OrderByDirection direction, string? expected)
+        {
+            DateTime? expectedDateTime = null;
+
+            if (expected is not null)
+            {
+                expectedDateTime = DateTime.Parse(expected);
+            }
+            
+            var query = new QueryOptions(
+                _edmType,
+                new FilterQueryOption(null),
+                new OrderByQueryOption(
+                    new []{new OrderByProperty(new EdmProperty(nameof(TestModel.OptionalDate), EdmPrimitiveType.Date, _edmType), direction)}    
+                ),
+                null,
+                0,
+                null,
+                10,
+                true
+            );
+
+            var results = _queryable.ToQueryResult(query);
+
+            results.Count.Should().Be(3);
+            results.Results.First().OptionalDate.Should().Be(expectedDateTime);
+        }
 
         [Fact]
         public void Should_filter_on_datetime_property_when_input_is_datetime()


### PR DESCRIPTION
Before if we order by a nullable property we would give an exception due to wrong delegate sign, the aim of this PR is to solve this issue.