### PR TITLE
fix(OrderBy): fixed support for nested properties in OrderBy clause

### DIFF
--- a/src/Scrima.Core/Query/OrderByProperty.cs
+++ b/src/Scrima.Core/Query/OrderByProperty.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Scrima.Core.Model;
 
 namespace Scrima.Core.Query
@@ -8,9 +11,22 @@ namespace Scrima.Core.Query
     /// </summary>
     public sealed class OrderByProperty
     {
-        public OrderByProperty(EdmProperty property, OrderByDirection direction)
+        public OrderByProperty(EdmProperty property, OrderByDirection direction) : this(new[] {property}, direction)
         {
-            Property = property ?? throw new ArgumentNullException(nameof(property));
+            
+        }
+        
+        public OrderByProperty(IEnumerable<EdmProperty> properties, OrderByDirection direction)
+        {
+            if (properties == null) throw new ArgumentNullException(nameof(properties));
+            
+            Properties = new ReadOnlyCollection<EdmProperty>(properties.ToList());
+            
+            if (Properties.Count == 0)
+            {
+                throw new InvalidOperationException("At least one order by property must be selected");
+            }
+            
             Direction = direction;
         }
 
@@ -20,10 +36,13 @@ namespace Scrima.Core.Query
         public OrderByDirection Direction { get; }
 
         /// <summary>
-        /// Gets the property to order by.
+        /// Gets the properties to order by.
         /// </summary>
-        public EdmProperty Property { get; }
+        public IReadOnlyList<EdmProperty> Properties { get; }
 
-        public override string ToString() => $"{Property.Name}-{Direction}";
+        public override string ToString()
+        {
+            return $"{string.Join(".", Properties)}-{Direction}";
+        }
     }
 }

--- a/src/Scrima.Core/Query/OrderByQueryOption.cs
+++ b/src/Scrima.Core/Query/OrderByQueryOption.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 

--- a/src/Scrima.Core/Scrima.Core.csproj
+++ b/src/Scrima.Core/Scrima.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Title>Scrima.NET Core</Title>
   </PropertyGroup>
 </Project>

--- a/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
+++ b/src/Scrima.EntityFrameworkCore/Scrima.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>6.0.1</Version>
+    <Version>6.0.2</Version>
     <Title>Scrima.NET execution engine for EntityFramework Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
+++ b/src/Scrima.OData.AspNetCore/Scrima.OData.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Title>Scrima.NET OData parsing for AspNet.Core</Title>
   </PropertyGroup>
 

--- a/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
+++ b/src/Scrima.OData.Swashbuckle/Scrima.OData.Swashbuckle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <Title>Scrima.NET OData Swagger schema for Swashbuckle</Title>
   </PropertyGroup>

--- a/src/Scrima.OData/ODataQueryParseHelper.cs
+++ b/src/Scrima.OData/ODataQueryParseHelper.cs
@@ -37,17 +37,14 @@ namespace Scrima.OData
 
             var parts = rawValue.Split(SplitCharacter.Space, StringSplitOptions.RemoveEmptyEntries);
 
-            EdmProperty property;
             var direction = OrderByDirection.Ascending;
 
-            if (parts.Length == 1)
-            {
-                property = model.GetProperty(parts[0]);
-            }
-            else
-            {
-                property = model.GetProperty(parts[0]);
+            var propertyName = parts[0];
 
+            var properties = PropertyParseHelper.ParseNestedProperties(propertyName, model);
+            
+            if (parts.Length != 1)
+            {
                 switch (parts[1])
                 {
                     case "asc":
@@ -63,7 +60,7 @@ namespace Scrima.OData
                 }
             }
 
-            return new OrderByProperty(property, direction);
+            return new OrderByProperty(properties, direction);
         }
 
         public static FilterQueryOption ParseFilter(string rawQuery, EdmComplexType model, EdmTypeProvider typeProvider)

--- a/src/Scrima.OData/Parsers/FilterExpressionParser.cs
+++ b/src/Scrima.OData/Parsers/FilterExpressionParser.cs
@@ -303,19 +303,7 @@ namespace Scrima.OData.Parsers
             
             private static PropertyAccessNode CreatePropertyAccessNode(string tokenValue, EdmComplexType edmComplexType)
             {
-                var properties = new List<EdmProperty>();
-                
-                foreach (var propertyName in tokenValue.Split('/'))
-                {
-                    if (edmComplexType is null)
-                    {
-                        throw new ODataParseException($"Property {propertyName} not found");
-                    }
-
-                    var currentProperty = edmComplexType.GetProperty(propertyName);
-                    properties.Add(currentProperty);
-                    edmComplexType = currentProperty.PropertyType as EdmComplexType;
-                }
+                var properties = PropertyParseHelper.ParseNestedProperties(tokenValue, edmComplexType);
 
                 var propertyAccessNode = new PropertyAccessNode(properties);
                 return propertyAccessNode;

--- a/src/Scrima.OData/Parsers/PropertyParseHelper.cs
+++ b/src/Scrima.OData/Parsers/PropertyParseHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Scrima.Core.Model;
+
+namespace Scrima.OData.Parsers;
+
+internal static class PropertyParseHelper
+{
+    public static IEnumerable<EdmProperty> ParseNestedProperties(string tokenValue, EdmComplexType edmComplexType)
+    {
+        var properties = new List<EdmProperty>();
+
+        foreach (var propertyName in tokenValue.Split('/'))
+        {
+            if (edmComplexType is null)
+            {
+                throw new ODataParseException($"Property {propertyName} not found");
+            }
+
+            var currentProperty = edmComplexType.GetProperty(propertyName);
+            properties.Add(currentProperty);
+            edmComplexType = currentProperty.PropertyType as EdmComplexType;
+        }
+
+        return properties;
+    }
+}

--- a/src/Scrima.OData/Scrima.OData.csproj
+++ b/src/Scrima.OData/Scrima.OData.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Title>Scrima.NET common utilities for OData</Title>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Extensions"/>
+    <Folder Include="Extensions" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Scrima.Core\Scrima.Core.csproj"/>
+    <ProjectReference Include="..\Scrima.Core\Scrima.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Scrima.Queryable/Scrima.Queryable.csproj
+++ b/src/Scrima.Queryable/Scrima.Queryable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.3</Version>
     <Title>Scrima.NET execution engine for IQueryable sources</Title>
   </PropertyGroup>
 

--- a/src/Scrima.Queryable/ScrimaExtensions.OrderBy.cs
+++ b/src/Scrima.Queryable/ScrimaExtensions.OrderBy.cs
@@ -32,7 +32,19 @@ namespace Scrima.Queryable
             foreach (var clause in orderByQueryOption.Properties)
             {
                 // o.PropertyName
-                var propertyExpression = Expression.Property(parameter, clause.Property.Name);
+                Expression propertyExpression = parameter;
+                
+                foreach (var edmProperty in clause.Properties)
+                {
+                    var property = propertyExpression.Type.GetProperty(edmProperty.Name);
+                
+                    if (property is null)
+                    {
+                        throw new QueryOptionsValidationException($"Invalid property name {edmProperty.Name}");
+                    }
+                
+                    propertyExpression = Expression.MakeMemberAccess(propertyExpression, property);
+                }
 
                 // o => o.PropertyName
                 var selectorExpression = Expression.Lambda(propertyExpression, parameter);

--- a/test/Scrima.Integration.Tests/DateFilterTests.cs
+++ b/test/Scrima.Integration.Tests/DateFilterTests.cs
@@ -40,6 +40,18 @@ namespace Scrima.Integration.Tests
             response.Results.Should().HaveCount(5);
         }
 
+        [Fact]
+        public async Task Should_ReturnFiltered_When_FilteringOnDateWithoutTime()
+        {
+            const int testUserCount = 10;
+            using var server = SetupSample(CreateUsers(testUserCount));
+            using var client = server.CreateClient();
+            
+            var response = await client.GetQueryAsync<User>($"/users?$filter=registrationDate gt 2021-01-05");
+
+            response.Results.Should().HaveCount(5);
+        }
+
         private static IEnumerable<User> CreateUsers(int testUserCount) =>
             Enumerable.Range(1, testUserCount).Select(i => new User
             {
@@ -48,6 +60,7 @@ namespace Scrima.Integration.Tests
                 FirstName = $"Jon{i}",
                 LastName = $"Smith{i}",
                 CreatedAt = new DateTimeOffset(2021, 1, i, 10, 0, 0, TimeSpan.Zero),
+                RegistrationDate = new DateTime(2021, 1, i, 0, 0, 0),
                 Engagement = 0.2 + i,
                 PayedAmout = (i % 2) * 25.30m,
                 Blogs = new List<Blog>
@@ -76,5 +89,5 @@ namespace Scrima.Integration.Tests
     /// <summary>
     /// replace internal modifier with public to run tests on SqlServer
     /// </summary>
-    internal class SqlServerDateFilterTests : DateFilterTests<SqlServerServicesInit> { }
+    public class SqlServerDateFilterTests : DateFilterTests<SqlServerServicesInit> { }
 }

--- a/test/Scrima.Integration.Tests/DateFilterTests.cs
+++ b/test/Scrima.Integration.Tests/DateFilterTests.cs
@@ -89,5 +89,5 @@ namespace Scrima.Integration.Tests
     /// <summary>
     /// replace internal modifier with public to run tests on SqlServer
     /// </summary>
-    public class SqlServerDateFilterTests : DateFilterTests<SqlServerServicesInit> { }
+    internal class SqlServerDateFilterTests : DateFilterTests<SqlServerServicesInit> { }
 }

--- a/test/Scrima.Integration.Tests/FilterTests.cs
+++ b/test/Scrima.Integration.Tests/FilterTests.cs
@@ -314,6 +314,7 @@ namespace Scrima.Integration.Tests
                 LastName = $"Smith{i}",
                 DomainId = $"Smith/{i}",
                 CreatedAt = new DateTimeOffset(2021, 1, i, 10, 0, 0, TimeSpan.Zero),
+                RegistrationDate = new DateTime(2021, 1, i, 0, 0, 0),
                 Engagement = 0.2 + i,
                 PayedAmout = (i % 2) * 25.30m,
                 Blogs = new List<Blog>

--- a/test/Scrima.Integration.Tests/Models/User.cs
+++ b/test/Scrima.Integration.Tests/Models/User.cs
@@ -15,6 +15,8 @@ namespace Scrima.Integration.Tests.Models
         public string Username { get; set; }
 
         public DateTimeOffset CreatedAt { get; set; }
+        [Column(TypeName = "datetime")]
+        public DateTime RegistrationDate { get; set; }
         
         public UserType Type { get; set; }
         public UserType SecondaryType { get; set; }
@@ -27,5 +29,6 @@ namespace Scrima.Integration.Tests.Models
         public double Engagement { get; set; }
         public decimal PayedAmout { get; set; }
         public string DomainId { get; set; } = string.Empty;
+        
     }
 }

--- a/test/Scrima.Integration.Tests/OrderByTests.cs
+++ b/test/Scrima.Integration.Tests/OrderByTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -12,10 +13,10 @@ namespace Scrima.Integration.Tests
     {
         private static User[] OrderByTestUsers => new[]
         {
-            new User {Username = "A", FirstName = "Name2"},
-            new User {Username = "B", FirstName = "Name1"},
-            new User {Username = "C", FirstName = "Name2"},
-            new User {Username = "D", FirstName = "Name1"}
+            new User {Username = "A", FirstName = "Name2", Blogs = new List<Blog> { new() { Name = "Blog1"}}},
+            new User {Username = "B", FirstName = "Name1", Blogs = new List<Blog> { new() { Name = "Blog2"}}},
+            new User {Username = "C", FirstName = "Name2", Blogs = new List<Blog> { new() { Name = "Blog3"}}},
+            new User {Username = "D", FirstName = "Name1", Blogs = new List<Blog> { new() { Name = "Blog4"}}},
         };
 
         [Fact]
@@ -38,6 +39,17 @@ namespace Scrima.Integration.Tests
             var response = await client.GetQueryAsync<User>("/users?$orderby=username");
             
             response.Results.Should().BeInAscendingOrder(r => r.Username);
+        }
+
+        [Fact]
+        public async Task Should_SortByNestedProperty_When_SlashIsFoundInName()
+        {
+            using var server = SetupSample(OrderByTestUsers);
+            using var client = server.CreateClient();
+
+            var response = await client.GetQueryAsync<Blog>("/blogs?$orderby=owner/username desc");
+            
+            response.Results.Should().BeInDescendingOrder(r => r.Name);
         }
 
         [Fact]


### PR DESCRIPTION
fixed order by nested property, it is now possible to sort results using the `PropertyName/SubPropertyName` syntax.